### PR TITLE
Fix process running before terminal is created (Windows only?)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ Initial release of lazygit for VSCode
 - If lazygit is already open, the focus is returned to the terminal, instead of opening a new instance of lazygit.
 - Fixed issue: when lazygit is opened, if any other terminals are active, terminal panel is not opened.
 
+
+### 1.0.6
+
+- Fixed issue: [BUG] Terminal does not move to editor consistently in WSL [#7](https://github.com/Chaitanya-Shahare/lazygit-for-vscode/issues/7) with [PR #9](https://github.com/Chaitanya-Shahare/lazygit-for-vscode/pull/9)
+
 <!-- Fixed issue #.
 
 ### 1.1.0

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -32,7 +32,7 @@ async function focusActiveLazygitInstance(): Promise<boolean> {
 async function newLazygitInstance() {
   // Always create a new terminal
   await vscode.commands.executeCommand(
-    "workbench.action.terminal.new"
+    "workbench.action.terminal.newInActiveWorkspace"
   );
 
   let terminal = vscode.window.activeTerminal!;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,8 +31,11 @@ async function focusActiveLazygitInstance(): Promise<boolean> {
 
 async function newLazygitInstance() {
   // Always create a new terminal
-  let terminal = vscode.window.createTerminal();
+  await vscode.commands.executeCommand(
+    "workbench.action.terminal.new"
+  );
 
+  let terminal = vscode.window.activeTerminal!;
   terminal.sendText("lazygit && exit");
   terminal.show();
 


### PR DESCRIPTION
This PR fixes https://github.com/Chaitanya-Shahare/lazygit-for-vscode/issues/7

It seems that when running `workbench.action.terminal.moveToEditor`, `vscode.window.createTerminal()` does not finish creating the terminal.

If the terminal does not exist.
The terminal is created in the terminal panel.

![image](https://github.com/Chaitanya-Shahare/lazygit-for-vscode/assets/60224604/77d42423-555f-4a7a-98f3-bfe5e4ebd031)

If the terminal already exists.
The existing terminal will be moved to the editor.

![image](https://github.com/Chaitanya-Shahare/lazygit-for-vscode/assets/60224604/9fd61609-31c5-4380-9dfc-7614fd248ba5)

The new terminal will remain in the terminal panel.

![image](https://github.com/Chaitanya-Shahare/lazygit-for-vscode/assets/60224604/3133060c-6a47-40fa-913f-32569b25e369)
