### PR TITLE
feat: allow configuring start delay

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,17 @@
         "mac": "cmd+g g",
         "linux": "ctrl+g g"
       }
-    ]
+    ],
+    "configuration": {
+      "title": "Lazygit",
+      "properties": {
+        "lazygit.startDelay": {
+          "type": "number",
+          "default": 0,
+          "description": "Delay in milliseconds after opening a new terminal before trying to start lazygit"
+        }
+      }
+    }
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -35,6 +35,11 @@ async function newLazygitInstance() {
     "workbench.action.terminal.newInActiveWorkspace"
   );
 
+  const startDelay = vscode.workspace.getConfiguration("lazygit").get("startDelay");
+  if (typeof startDelay === "number" && startDelay > 0) {
+    await new Promise((resolve) => setTimeout(resolve, startDelay));
+  }
+
   let terminal = vscode.window.activeTerminal!;
   terminal.sendText("lazygit && exit");
   terminal.show();


### PR DESCRIPTION
Sometimes the shell just takes longer to actually start up so the "sendText" command is executed before the shell is actually ready to accept commands.